### PR TITLE
Using fully qualified node names

### DIFF
--- a/README
+++ b/README
@@ -32,11 +32,6 @@ document (for now). Also links are not shown.
 The Heading Type must at least consist of the attribute 'Description'. Any other
 attributes are ignored and will not be shown in the Latex/PDF document.
 
-Preparing the reqif file
-------------------------
-Make a copy of the requif file. Change the copy by removing all the namespaces
-from the root <REQ-IF> node (not sure why that it is needed).
-
 Convert the modified reqif file into latex
 ------------------------------------------
 You need a xslt processor. I used xsltproc. Run the following command:

--- a/reqif2Latex.xsl
+++ b/reqif2Latex.xsl
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
-xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:reqif="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd">
   <xsl:param name="specmode" select="'spec'"/>
   <xsl:output method="text"/>
-  <xsl:key name="req_text" match="/REQ-IF/CORE-CONTENT/REQ-IF-CONTENT/SPEC-OBJECTS/SPEC-OBJECT" use="@IDENTIFIER"/>
-  <xsl:key name="attr_type" match="/REQ-IF/CORE-CONTENT/REQ-IF-CONTENT/SPEC-TYPES/SPEC-OBJECT-TYPE/SPEC-ATTRIBUTES/ATTRIBUTE-DEFINITION-STRING" use="@IDENTIFIER"/>
-  <xsl:key name="obj_type" match="/REQ-IF/CORE-CONTENT/REQ-IF-CONTENT/SPEC-TYPES/SPEC-OBJECT-TYPE" use="@IDENTIFIER"/>
+  <xsl:key name="req_text" match="/reqif:REQ-IF/reqif:CORE-CONTENT/reqif:REQ-IF-CONTENT/reqif:SPEC-OBJECTS/reqif:SPEC-OBJECT" use="@IDENTIFIER"/>
+  <xsl:key name="attr_type" match="/reqif:REQ-IF/reqif:CORE-CONTENT/reqif:REQ-IF-CONTENT/reqif:SPEC-TYPES/reqif:SPEC-OBJECT-TYPE/reqif:SPEC-ATTRIBUTES/reqif:ATTRIBUTE-DEFINITION-STRING" use="@IDENTIFIER"/>
+  <xsl:key name="obj_type" match="/reqif:REQ-IF/reqif:CORE-CONTENT/reqif:REQ-IF-CONTENT/reqif:SPEC-TYPES/reqif:SPEC-OBJECT-TYPE" use="@IDENTIFIER"/>
 
   <xsl:template match="/">
-      <xsl:apply-templates select="/REQ-IF/CORE-CONTENT/REQ-IF-CONTENT/SPECIFICATIONS/SPECIFICATION"/>
+      <xsl:apply-templates select="/reqif:REQ-IF/reqif:CORE-CONTENT/reqif:REQ-IF-CONTENT/reqif:SPECIFICATIONS/reqif:SPECIFICATION"/>
   </xsl:template>
 
   <!-- We start with the specification -->
-  <xsl:template match="/REQ-IF/CORE-CONTENT/REQ-IF-CONTENT/SPECIFICATIONS/SPECIFICATION">
+  <xsl:template match="/reqif:REQ-IF/reqif:CORE-CONTENT/reqif:REQ-IF-CONTENT/reqif:SPECIFICATIONS/reqif:SPECIFICATION">
 \documentclass[a4paper,notitlepage]{scrartcl}  
 \begin{document}
-\title{<xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING/@THE-VALUE"/>}
+\title{<xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING/@THE-VALUE"/>}
 \maketitle
-      <xsl:apply-templates select="CHILDREN">
+      <xsl:apply-templates select="reqif:CHILDREN">
         <xsl:with-param name="level" select="1"/>
       </xsl:apply-templates>
 \end{document}
@@ -25,9 +26,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:template name="requirements-template-brochure">
     <xsl:text>\pdftooltip{</xsl:text>
-    <xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING[key('attr_type',DEFINITION/ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
+    <xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING[key('attr_type',reqif:DEFINITION/reqif:ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
     <xsl:text>}{</xsl:text>
-    <xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING[key('attr_type',DEFINITION/ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='ID']/@THE-VALUE"/>
+    <xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING[key('attr_type',reqif:DEFINITION/reqif:ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='ID']/@THE-VALUE"/>
     <xsl:text>}
     </xsl:text>
   </xsl:template>
@@ -35,9 +36,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:template name="requirements-template-spec">
     <xsl:text>\begin{description}
 \item[</xsl:text>
-    <xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING[key('attr_type',DEFINITION/ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='ID']/@THE-VALUE"/>
+    <xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING[key('attr_type',reqif:DEFINITION/reqif:ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='ID']/@THE-VALUE"/>
     <xsl:text>]</xsl:text>
-    <xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING[key('attr_type',DEFINITION/ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
+    <xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING[key('attr_type',reqif:DEFINITION/reqif:ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
     <xsl:text>
 \end{description}
     </xsl:text>
@@ -51,26 +52,26 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
       <xsl:when test="$level = 3">\subsubsection{</xsl:when>
       <xsl:otherwise>\paragraph{</xsl:otherwise>
     </xsl:choose>
-    <xsl:value-of select="VALUES/ATTRIBUTE-VALUE-STRING[key('attr_type',DEFINITION/ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
+    <xsl:value-of select="reqif:VALUES/reqif:ATTRIBUTE-VALUE-STRING[key('attr_type',reqif:DEFINITION/reqif:ATTRIBUTE-DEFINITION-STRING-REF)/@LONG-NAME='Description']/@THE-VALUE"/>
     <xsl:text>}
     </xsl:text>
   </xsl:template>
 
 
   <!-- <CHILDREN> with <SPEC-HIERARCHY> are nested throughout the specification -->
-  <xsl:template match="CHILDREN[SPEC-HIERARCHY]">
+  <xsl:template match="reqif:CHILDREN[reqif:SPEC-HIERARCHY]">
     <xsl:param name="level"/>
-      <xsl:apply-templates select="SPEC-HIERARCHY">
+      <xsl:apply-templates select="reqif:SPEC-HIERARCHY">
         <xsl:with-param name="level" select="$level"/>
       </xsl:apply-templates>
   </xsl:template>
 
   <!-- <SPEC-HIERARCHY> with @IDENTIFIER provides the actial content -->
-  <xsl:template match="SPEC-HIERARCHY[@IDENTIFIER]">
+  <xsl:template match="reqif:SPEC-HIERARCHY[@IDENTIFIER]">
     <xsl:param name="level" select="0"/>
-    <xsl:variable name="item_text"> <xsl:value-of select="OBJECT/SPEC-OBJECT-REF"/></xsl:variable>
+    <xsl:variable name="item_text"> <xsl:value-of select="reqif:OBJECT/reqif:SPEC-OBJECT-REF"/></xsl:variable>
     <xsl:for-each select="key('req_text',$item_text)">
-      <xsl:variable name="object_type"> <xsl:value-of select="TYPE/SPEC-OBJECT-TYPE-REF"/></xsl:variable>
+      <xsl:variable name="object_type"> <xsl:value-of select="reqif:TYPE/reqif:SPEC-OBJECT-TYPE-REF"/></xsl:variable>
       <xsl:choose>
         <xsl:when test="key('obj_type',$object_type)/@LONG-NAME = 'Requirement Type'">
           <!-- The current object is a requirement, we want it's ID and description -->
@@ -89,7 +90,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
         </xsl:when>
       </xsl:choose>
     </xsl:for-each>
-    <xsl:apply-templates select="CHILDREN">
+    <xsl:apply-templates select="reqif:CHILDREN">
       <xsl:with-param name="level" select="$level+1"/>
     </xsl:apply-templates>
   </xsl:template>


### PR DESCRIPTION
Using fully qualified node names it is not necessary anymore to modify the ReqIF file prior to processing.
